### PR TITLE
Minimal phone notification: single body, no click handler

### DIFF
--- a/docs/pair/sw.js
+++ b/docs/pair/sw.js
@@ -1,29 +1,15 @@
 // OpenFeedling phone-side service worker.
 // Receives web push events from the paired extension (via FCM/Mozilla autopush)
-// and renders a native notification.
+// and renders a native notification. Empty payloads are intentional for v0;
+// per-notification body/icon would require RFC 8291 payload encryption.
+
+const ICON = "https://teleport-computer.github.io/open-feedling-web/store-icon-128.png";
 
 self.addEventListener("push", (event) => {
-  let title = "OpenFeedling";
-  let body = "Cat noticed you've been scrolling.";
-  if (event.data) {
-    try {
-      const j = event.data.json();
-      title = j.title || title;
-      body = j.body || body;
-    } catch {
-      body = event.data.text() || body;
-    }
-  }
-  event.waitUntil(self.registration.showNotification(title, {
-    body,
-    icon: "https://teleport-computer.github.io/open-feedling-web/store-icon-128.png",
-    badge: "https://teleport-computer.github.io/open-feedling-web/store-icon-128.png",
+  event.waitUntil(self.registration.showNotification("OpenFeedling", {
+    body: "5 minutes of shorts. Cat says: please.",
+    icon: ICON,
+    badge: ICON,
     tag: "openfeedling",
-    renotify: true,
   }));
-});
-
-self.addEventListener("notificationclick", (event) => {
-  event.notification.close();
-  event.waitUntil(self.clients.openWindow("https://www.youtube.com/"));
 });


### PR DESCRIPTION
Drops the per-trigger body parsing and notificationclick handler from `docs/pair/sw.js`. Notification = one canonical line + cat icon + tag. Tap dismisses, no "next page" to design.

Dynamic content (per-trigger body, LLM roast, varying icon) requires RFC 8291 aes128gcm payload encryption; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)