### PR TITLE
Popup pair button + OpenRouter placeholder + green CI + rewritten Pages homepage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,11 +9,17 @@ on:
     - cron: "0 6 * * 1"
 
 jobs:
-  e2e:
+  extension-only:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: test/package-lock.json
 
       - name: Sanity-check secret is set
         env:
@@ -24,16 +30,28 @@ jobs:
             exit 1
           fi
 
-      - name: Run E2E
+      - name: Materialize cookies.json
         env:
           YT_COOKIES_JSON: ${{ secrets.YT_COOKIES_JSON }}
-        working-directory: test
-        run: docker compose up --build --abort-on-container-exit --exit-code-from e2e
+        run: printf '%s' "$YT_COOKIES_JSON" > test/cookies.json
 
-      - name: Upload Playwright report
-        if: always()
+      - name: Install test deps
+        working-directory: test
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: test
+        run: npx playwright install --with-deps chromium
+
+      - name: Run extension-only spec
+        working-directory: test
+        run: npx playwright test extension-only.spec.ts --reporter=list
+
+      - name: Upload Playwright output on failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: test/playwright-report
+          name: playwright-output
+          path: /tmp/pw-out
           retention-days: 14
+          if-no-files-found: ignore

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 title: OpenFeedling
 ---
 
-A self-hostable browser extension + server that watches your YouTube history and sends you a gentle push notification when you've been scrolling shorts too long. The cat gets tired so you don't have to.
+A browser extension that watches your YouTube history and gives you a gentle nudge when you've been scrolling Shorts too long. The cat gets tired so you don't have to.
 
 - **Source code**: [github.com/teleport-computer/open-feedling-web](https://github.com/teleport-computer/open-feedling-web)
 - **License**: MIT
@@ -10,58 +10,56 @@ A self-hostable browser extension + server that watches your YouTube history and
 
 ## How it works
 
-1. Install the OpenFeedling extension in Chrome
-2. Run the OpenFeedling server (your laptop, a VPS, Vercel, or your own dstack)
-3. The extension keeps your YouTube cookies fresh on the server
-4. The server polls YouTube on its own schedule and fires a Web Push when scrolling crosses a threshold
-5. Push lands on whichever device you've subscribed (laptop, phone, or both)
+1. Install the extension. Click its icon — it shows your YouTube watch history right there.
+2. Tick **"Doomscroll notifications"**. The extension polls your history every minute and fires a native browser notification after five consecutive minutes of new Shorts.
+3. Optionally, scan a QR with your phone to also receive the notification on mobile.
 
-The server is the always-on poller, so the loop break still fires when your laptop is closed and you're scrolling on your phone.
+Everything runs locally in your browser. No server to host, no cookies to sync, no tunnels. The optional phone-pairing handshake uses [ntfy.sh](https://ntfy.sh) once at pairing time; ongoing pushes go straight from your extension to your phone's push service via VAPID.
 
-## Run it yourself (~5 minutes, Mac + Chrome)
+## Install (~2 minutes)
 
-You need a Chromium-based browser, [Deno](https://docs.deno.com/runtime/getting_started/installation/), and [git](https://git-scm.com/).
+The Chrome Web Store listing is coming. For now, load the extension from a local clone:
 
 ```bash
-# 1. Install Deno if you don't have it
-brew install deno
-
-# 2. Clone and set up env
 git clone https://github.com/teleport-computer/open-feedling-web.git
-cd open-feedling-web
-deno task gen-vapid > .env
-echo "VAPID_SUBJECT=mailto:test@example.com" >> .env
-echo "EXT_SHARED_SECRET=$(openssl rand -hex 32)" >> .env
-
-# 3. Run the server
-deno task start
-# → listening on http://localhost:3000
 ```
 
-Then in Chrome:
+In Chrome (or any Chromium browser):
 
-1. Go to `chrome://extensions` and toggle **Developer mode** (top right)
-2. Click **Load unpacked** → select the `extension/` folder you just cloned
-3. Click the OpenFeedling icon (pin it via the puzzle-piece menu for sanity)
-4. Paste `http://localhost:3000` into "Server URL", paste your `EXT_SHARED_SECRET` from `.env` into "Shared secret", click **Save & sync now** — popup should report ✓ synced N cookies
-5. Open `http://localhost:3000` → click **enable push** → grant the notification permission
-6. Click **send test push** to confirm it works
-7. Open YouTube, scroll a few shorts. The cat will fill up over the next few minutes.
+1. Open `chrome://extensions` and toggle **Developer mode** (top right).
+2. Click **Load unpacked** and pick the `extension/` folder you just cloned.
+3. Pin the OpenFeedling icon via the puzzle-piece menu.
+4. Click the icon. The popup should populate with your shorts-today / total-in-history count within ~1 second.
 
-### Add your phone (optional)
+That's it. No setup, no config.
 
-Web Push needs HTTPS or `localhost`. Your phone reaches your laptop at plain HTTP, which mobile browsers reject — so you need a tunnel:
+## Turn on notifications
 
-```bash
-brew install ngrok
-ngrok http 3000
-# → https://abc123.ngrok.app
-```
+In the popup, tick **Doomscroll notifications**. From now on, when the extension detects five consecutive minutes of new Shorts in your watch history, your laptop browser shows a native notification: *"5 minutes of shorts. Cat says: please."*
 
-Reload the dashboard at the ngrok URL, re-point the extension at it, click **share to phone** → scan the QR with your phone → tap **enable push** on your phone. Done — you'll get a notification on both devices.
+To test it: open `youtube.com/shorts` and scroll continuously for 5 minutes. (Or click **Open dashboard** → **send test notification** to verify your browser actually shows them.)
+
+## Add your phone (optional)
+
+1. In the popup, click **📱 Pair phone**. A dashboard tab opens with a QR code.
+2. Scan the QR with your phone camera. A page on this site (`/pair/`) explains what's about to happen.
+3. Tap **Subscribe to alerts** on your phone and grant the notification permission.
+4. Within a few seconds the extension picks up the pairing. The dashboard transitions to "✓ phone subscribed".
+5. Click **Send test push** in the dashboard. Your phone should show a real native notification.
+
+The pairing handshake uses a one-time [ntfy.sh](https://ntfy.sh) topic. Once your phone is paired, ongoing pushes go directly from your extension to FCM (or Mozilla autopush, or Apple) using a VAPID-signed JWT — nothing routes through ntfy after pairing.
+
+## BYO server (optional, advanced)
+
+If you want cross-device cookie sync — say, your laptop browser keeps the cookies fresh on a server and the server polls YouTube even when your laptop is asleep — you can run the included Deno server on Vercel, Render, or your own VPS. Click ⚙ in the popup to enter a server URL + shared secret.
+
+Most users don't need this. The default extension-only flow already covers the common case ("I want a nudge when I'm wasting time on this laptop").
 
 ## Trust model
 
-This is a self-host kit — you run both the server and the extension; you control your cookies end-to-end. No third-party trust needed for the data path.
+This extension polls your YouTube history directly from your own browser using your existing session cookies. None of that data leaves your machine unless you opt into one of:
 
-See the [README](https://github.com/teleport-computer/open-feedling-web#trust-model) for details on how this differs from a TEE-attested community deployment.
+- **Phone pairing**: ~300 bytes of push-subscription metadata transit ntfy.sh once at pairing time.
+- **BYO server**: your cookies go to a server you operate.
+
+In the default extension-only flow with no phone paired, no third party touches your data.

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -63,6 +63,17 @@
     <div id="history" class="err">loading watch history...</div>
   </div>
 
+  <div class="card" id="advancedCard">
+    <div class="phone-title">⚙ Advanced</div>
+    <div class="phone-status">Coming soon: pasting an OpenRouter API key here will unlock LLM-generated push notifications (e.g. "you watched 7 minutes of skateboarding fail compilations and a video about whether birds are real, the cat is genuinely worried"). Stored locally; no effect yet.</div>
+    <label style="display:block;font-size:0.78rem;color:#888;margin:8px 0 4px">OpenRouter API key</label>
+    <input id="openrouterKey" type="password" placeholder="sk-or-v1-..." style="width:100%;padding:8px 10px;border:1px solid #ddd;border-radius:8px;box-sizing:border-box;font-size:13px;font-family:ui-monospace,monospace">
+    <div class="phone-actions" style="margin-top:10px">
+      <button class="ghost" id="saveAdvanced">Save</button>
+    </div>
+    <div class="phone-status" id="advancedStatus" style="margin-top:6px"></div>
+  </div>
+
   <div class="foot">openfeedling · runs entirely in your browser</div>
 </div>
 <script src="vendor/qrcode.js"></script>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -158,15 +158,31 @@ async function loadPhone() {
     renderQRBody(pairTopic, pairUrl);
     setPhoneStatus("resuming — waiting for phone");
     pollLoop(pairTopic);
+  } else if (location.hash === "#pair") {
+    // Deep link from popup's "Pair phone" button — skip the unpaired state, go straight to QR
+    startPairing();
   } else {
     setPhoneStatus("not paired");
     renderUnpaired();
   }
 }
 
+async function loadAdvanced() {
+  const { openrouterKey } = await chrome.storage.local.get(["openrouterKey"]);
+  $("openrouterKey").value = openrouterKey || "";
+}
+
+$("saveAdvanced")?.addEventListener("click", async () => {
+  const key = $("openrouterKey").value.trim();
+  await chrome.storage.local.set({ openrouterKey: key });
+  $("advancedStatus").textContent = key ? "✓ saved (no effect yet — feature in flight)" : "cleared";
+  $("advancedStatus").style.color = "#2a8";
+});
+
 (async () => {
   const { lastSnapshot } = await chrome.storage.local.get(["lastSnapshot"]);
   if (lastSnapshot) render(lastSnapshot);
   loadPhone();
+  loadAdvanced();
   refresh();
 })();

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -15,6 +15,8 @@
   .pill .age { color:#aaa; font-size:0.75rem; display:block; margin-top:2px; }
   .pill.err { background:#FDE0E0; color:#c33; }
   button.primary { padding:9px 12px; border:0; background:#FF9B85; color:#fff; border-radius:6px; cursor:pointer; width:100%; font-weight:600; font-size:13px; }
+  button.secondary { padding:8px 12px; border:1px solid #FF9B85; background:transparent; color:#FF9B85; border-radius:6px; cursor:pointer; width:100%; font-weight:600; font-size:13px; margin-top:8px; }
+  .paired-note { font-size:0.7rem; color:#2a8; margin-top:4px; text-align:center; }
   .toggle { display:flex; align-items:center; gap:8px; margin-top:10px; padding:8px 4px; cursor:pointer; user-select:none; }
   .toggle input { accent-color:#FF9B85; cursor:pointer; }
   .toggle .label { flex:1; }
@@ -49,6 +51,9 @@
   </span>
 </label>
 <div class="confirm" id="confirm"></div>
+
+<button class="secondary" id="pairPhone">📱 Pair phone</button>
+<div class="paired-note" id="pairedNote"></div>
 
 <div class="config" id="config">
   <div class="hint">Optional: BYO server (Vercel/Render/etc.) for cross-device push.</div>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -56,6 +56,11 @@ $("dash").onclick = () => {
   window.close();
 };
 
+$("pairPhone").onclick = () => {
+  chrome.tabs.create({ url: chrome.runtime.getURL("dashboard.html#pair") });
+  window.close();
+};
+
 $("notify").onchange = async (e) => {
   const enabled = e.target.checked;
   await chrome.storage.local.set({ notifyEnabled: enabled });
@@ -94,8 +99,12 @@ $("save").onclick = async () => {
 };
 
 (async () => {
-  const { notifyEnabled, lastSnapshot } = await chrome.storage.local.get(["notifyEnabled", "lastSnapshot"]);
+  const { notifyEnabled, lastSnapshot, phoneSub } = await chrome.storage.local.get(["notifyEnabled", "lastSnapshot", "phoneSub"]);
   $("notify").checked = !!notifyEnabled;
+  if (phoneSub) {
+    $("pairPhone").textContent = "📱 Phone paired — re-pair";
+    $("pairedNote").textContent = "✓ a phone is paired";
+  }
   setPill({ snap: lastSnapshot || null, refreshing: !lastSnapshot || Date.now() - lastSnapshot.at > 30_000 });
   if (!lastSnapshot || Date.now() - lastSnapshot.at > 30_000) {
     try {

--- a/test/extension-only.spec.ts
+++ b/test/extension-only.spec.ts
@@ -186,6 +186,30 @@ test("share-to-phone: paired state shows test/forget; forget clears storage", as
   await context.close();
 });
 
+test("dashboard #pair deep link auto-starts pairing", async () => {
+  const { context, extensionId } = await bootContext();
+  const dash = await context.newPage();
+  await dash.goto(`chrome-extension://${extensionId}/dashboard.html#pair`);
+  await expect(dash.locator(".qr-wrap img")).toBeVisible({ timeout: 10_000 });
+  const status = await dash.locator("#phoneStatus").innerText();
+  expect(status).toMatch(/waiting for phone/);
+  await context.close();
+});
+
+test("OpenRouter key placeholder persists", async () => {
+  const { context, extensionId } = await bootContext();
+  const dash = await context.newPage();
+  await dash.goto(`chrome-extension://${extensionId}/dashboard.html`);
+  await expect(dash.locator("#openrouterKey")).toBeVisible({ timeout: 10_000 });
+  await dash.fill("#openrouterKey", "sk-or-v1-test-placeholder-key");
+  await dash.click("#saveAdvanced");
+  await expect(dash.locator("#advancedStatus")).toContainText("saved", { timeout: 5_000 });
+  await dash.reload();
+  const v = await dash.locator("#openrouterKey").inputValue();
+  expect(v).toBe("sk-or-v1-test-placeholder-key");
+  await context.close();
+});
+
 test("notifyEnabled flag persists across popup → dashboard", async () => {
   const { context, extensionId } = await bootContext();
   const popup = await context.newPage();


### PR DESCRIPTION
Three loosely-related improvements bundled because they're all small.

## 1. Extension UX (commit d3714cd)
- Popup "📱 Pair phone" button under the doomscroll toggle. Opens dashboard with `#pair` hash → auto-starts QR flow on load.
- New "⚙ Advanced" card on dashboard with OpenRouter API key placeholder. No effect yet (LLM-roast push body needs RFC 8291 payload encryption first), but lets power users plant their key now.
- 2 new Playwright tests for the deep link + key persistence. **9/9 pass**.

## 2. CI fix (commit f4d923c)
The previous workflow ran the old `e2e.spec.ts` (BYO-server flow) under docker compose. After the architecture pivot, that spec's assumptions (visible `#serverUrl` in popup, InnerTube poll path) are stale and CI has failed on every PR since.

Replaced with a lean native-Playwright run of `extension-only.spec.ts`:
- No docker / compose / container builds
- ~2min CI vs previous ~5min
- Actually tests the local-only path users follow now

The BYO-server `e2e.spec.ts` stays in the repo for manual runs; updating it for the ⚙-gated popup form is separate work.

## 3. Docs rewrite (commit b2f4b5b)
The Pages homepage described the BYO-server flow as the default. After the pivot, the canonical flow is:

1. Load unpacked from git clone (Web Store coming)
2. Click icon → popup shows your shorts count in ~1s
3. Tick "Doomscroll notifications" → laptop alerts
4. Optional: click "Pair phone" → scan QR → phone alerts
5. Optional/advanced: BYO server for cross-device cookie sync

Trust model section now itemizes what (if anything) leaves the machine per opt-in mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)